### PR TITLE
Fixing wrong version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 project(Forkserf)
-set(PROJECT_VERSION "0.6.2")
+set(PROJECT_VERSION "0.6.3")
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/src/version-vcs.h
+++ b/src/version-vcs.h
@@ -1,6 +1,6 @@
 #ifndef VERSION_VCS_H
 #define VERSION_VCS_H
 
-#define VERSION_VCS "0.6.2"
+#define VERSION_VCS "0.6.3"
 
 #endif /* VERSION_VCS_H */


### PR DESCRIPTION
It is unclear what the version number should be. Code is 0.6.2, but the latest downloadable file is named 0.6.3, but it shows 0.6.2 when running.