### PR TITLE
Fixing incorrect number of buildings

### DIFF
--- a/src/gfx.cc
+++ b/src/gfx.cc
@@ -705,18 +705,22 @@ Frame::draw_string(int x, int y, const std::string &str, const Color &color,
 }
 
 /* Draw the number n at x, y in the dest frame. */
-void
+// Returns the number of characters drawn.
+int
 Frame::draw_number(int x, int y, int value, const Color &color,
                    const Color &shadow) {
+  int charactersDrawn = 0;
   if (value < 0) {
     draw_char_sprite(x, y, '-', color, shadow);
     x += 8;
     value *= -1;
+    charactersDrawn++;
   }
 
   if (value == 0) {
     draw_char_sprite(x, y, '0', color, shadow);
-    return;
+    charactersDrawn++;
+    return charactersDrawn;
   }
 
   int digits = 0;
@@ -724,8 +728,10 @@ Frame::draw_number(int x, int y, int value, const Color &color,
 
   for (int i = digits-1; i >= 0; i--) {
     draw_char_sprite(x+8*i, y, '0'+(value % 10), color, shadow);
+    charactersDrawn++;
     value /= 10;
   }
+  return charactersDrawn;
 }
 
 /* Draw a rectangle with color at x, y in the dest frame. */

--- a/src/gfx.h
+++ b/src/gfx.h
@@ -160,7 +160,7 @@ class Frame {
   /* Text functions */
   void draw_string(int x, int y, const std::string &str, const Color &color,
                    const Color &shadow = Color::transparent);
-  void draw_number(int x, int y, int value, const Color &color,
+  int draw_number(int x, int y, int value, const Color &color,
                    const Color &shadow = Color::transparent);
 
   /* Frame functions */

--- a/src/player.cc
+++ b/src/player.cc
@@ -1258,7 +1258,7 @@ operator >> (SaveReaderBinary &reader, Player &player)  {
 
   for (int j = 0; j < 23; j++) { // This should not be 24 as Building::TypeNone is not loaded
     reader >> v16;  // 132
-    player.completed_building_count[j + 1] = v16; // + 1 because index 0 is Building::TypeNone, index 1 Building::TypeFisher and so on
+    player.completed_building_count[j + 1] = v16; // The + 1 is because index 0 is Building::TypeNone, index 1 is Building::TypeFisher and so on
   }
   for (int j = 0; j < 23; j++) { // See above
     reader >> v16;  // 178
@@ -1410,9 +1410,10 @@ operator >> (SaveReaderText &reader, Player &player) {
   if (reader.has_value("version")) {
 	  reader.value("version") >> version;
   }
-  // This a attempt correct bad saved game data
-  // Index 0 should have been the number of Building::TypeFisher's, but was number of Building::TypeNone.
-  // This has been fixed in version == 1
+  // This is an attempt to fix incorrect saved game data.
+  // Index 0 should have been the number of Building::TypeFishers, but it was the number of Building::TypeNone.
+  // Note: The number of Building::TypeGoldSmelter was not saved in the saved game, and is therefore lost.
+  // This has been fixed in version == 1.
   int start_index = version == 0 ? 1 : 0;
   int offset = version == 0 ? 0 : 1;
   for (int i = start_index; i < 23; i++) { // This should not be 24 as Building::TypeNone is not loaded

--- a/src/player.cc
+++ b/src/player.cc
@@ -1256,13 +1256,13 @@ operator >> (SaveReaderBinary &reader, Player &player)  {
   reader >> v8;  // 131
   player.build = v8;
 
-  for (int j = 0; j < 23; j++) {
+  for (int j = 0; j < 23; j++) { // This should not be 24 as Building::TypeNone is not loaded
     reader >> v16;  // 132
-    player.completed_building_count[j] = v16;
+    player.completed_building_count[j + 1] = v16; // + 1 because index 0 is Building::TypeNone, index 1 Building::TypeFisher and so on
   }
-  for (int j = 0; j < 23; j++) {
+  for (int j = 0; j < 23; j++) { // See above
     reader >> v16;  // 178
-    player.incomplete_building_count[j] = v16;
+    player.incomplete_building_count[j + 1] = v16; // See above
   }
 
   for (int j = 0; j < 26; j++) {
@@ -1405,11 +1405,21 @@ operator >> (SaveReaderText &reader, Player &player) {
     reader.value("knight_occupation")[i] >> player.knight_occupation[i];
     reader.value("attacking_knights")[i] >> player.attacking_knights[i];
   }
-  for (int i = 0; i < 23; i++) {
+
+  int version = 0;
+  if (reader.has_value("version")) {
+	  reader.value("version") >> version;
+  }
+  // This a attempt correct bad saved game data
+  // Index 0 should have been the number of Building::TypeFisher's, but was number of Building::TypeNone.
+  // This has been fixed in version == 1
+  int start_index = version == 0 ? 1 : 0;
+  int offset = version == 0 ? 0 : 1;
+  for (int i = start_index; i < 23; i++) { // This should not be 24 as Building::TypeNone is not loaded
     reader.value("completed_building_count")[i] >>
-      player.completed_building_count[i];
+      player.completed_building_count[i + offset];
     reader.value("incomplete_building_count")[i] >>
-      player.incomplete_building_count[i];
+      player.incomplete_building_count[i + offset];
   }
   for (int i = 0; i < 64; i++) {
     reader.value("attacking_buildings")[i] >> player.attacking_buildings[i];
@@ -1474,7 +1484,9 @@ operator << (SaveWriterText &writer, Player &player) {
     writer.value("attacking_knights") << player.attacking_knights[i];
   }
 
-  for (int i = 0; i < 23; i++) {
+  // See comment in SaveReaderText& operator >> (SaveReaderText &reader, Player &player);
+  writer.value("version") << "1";
+  for (int i = Building::TypeFisher; i < Building::TypeCastle; i++) { // This should not be 0 (Building::TypeFisher == 1) as Building::TypeNone is not saved
     writer.value("completed_building_count") <<
       player.completed_building_count[i];
     writer.value("incomplete_building_count") <<

--- a/src/player.h
+++ b/src/player.h
@@ -97,8 +97,8 @@ class Player : public GameObject {
   size_t face;
   int flags;
   int build;
-  int completed_building_count[24];
-  int incomplete_building_count[24];
+  int completed_building_count[24]; // This includes all the building types including Building::TypeNone, but it doesn't include the Building::TypeCastle!
+  int incomplete_building_count[24]; // See above.
   int inventory_prio[26];
   int attacking_buildings[64];
 

--- a/src/popup.cc
+++ b/src/popup.cc
@@ -478,34 +478,42 @@ PopupBox::draw_green_string(int sx, int sy, const std::string &str) {
 /* Draw a green number in a popup frame.
    n must be non-negative. If > 999 simply draw three characters xxT or Mx thousands, xxM or Mx for millions, xxB for bilions. */
 // includes p1plp1's "millions and billions"... though likely only Thousands ever seen
-void
+// Returns the number of characters drawn.
+int
 PopupBox::draw_green_number(int sx, int sy, int n) {
+  int charactersDrawn = 0;
   if (n >= 1000000000) {
     /*billion*/
     int ntmp = n / 1000000000;
-    frame->draw_number(8 * sx + 8, 9 + sy, ntmp, Color::green);
-    frame->draw_string(8 * (sx + (ntmp < 10 ? 1 : 2)) + 8, sy + 9, "B", Color::green);
+    charactersDrawn += frame->draw_number(8 * sx + 8, 9 + sy, ntmp, Color::green);
+    frame->draw_string(8 * (sx + charactersDrawn) + 8, sy + 9, "B", Color::green);
+    charactersDrawn++;
   } else if (n >= 100000000) {
     int ntmp = n / 100000000;
     frame->draw_string(8 * sx + 8, sy + 9, "B", Color::green);
-    frame->draw_number(8 * (sx + 1) + 8, 9 + sy, ntmp, Color::green);
+    charactersDrawn++;
+    charactersDrawn += frame->draw_number(8 * (sx + charactersDrawn) + 8, 9 + sy, ntmp, Color::green);
   } else if (n >= 1000000) {
     /*million*/
     int ntmp = n / 1000000;
-    frame->draw_number(8 * sx + 8, 9 + sy, ntmp, Color::green);
-    frame->draw_string(8 * (sx + (ntmp < 10 ? 1 : 2)) + 8, sy + 9, "M", Color::green);
+    charactersDrawn += frame->draw_number(8 * sx + 8, 9 + sy, ntmp, Color::green);
+    frame->draw_string(8 * (sx + charactersDrawn) + 8, sy + 9, "M", Color::green);
+    charactersDrawn++;
   } else if (n >= 100000) {
     int ntmp =  n / 100000;
     frame->draw_string(8 * sx + 8, sy + 9, "M", Color::green);
-    frame->draw_number(8 * (sx + 1) + 8, 9 + sy, ntmp, Color::green);
+    charactersDrawn++;
+    charactersDrawn += frame->draw_number(8 * (sx + charactersDrawn) + 8, 9 + sy, ntmp, Color::green);
   } else if (n >= 1000) {
     /* thousand */
     int ntmp =  n / 1000;
-    frame->draw_number(8 * sx + 8, 9 + sy, ntmp, Color::green);
-    frame->draw_string(8 * (sx + (ntmp < 10 ? 1 : 2)) + 8, sy + 9, "k", Color::green);
+    charactersDrawn += frame->draw_number(8 * sx + 8, 9 + sy, ntmp, Color::green);
+    frame->draw_string(8 * (sx + charactersDrawn) + 8, sy + 9, "k", Color::green);
+    charactersDrawn++;
   } else {
-    frame->draw_number(8 * sx + 8, 9 + sy, n, Color::green);
+    charactersDrawn += frame->draw_number(8 * sx + 8, 9 + sy, n, Color::green);
   }
+  return charactersDrawn;
 }
 
 /* Draw a green number in a popup frame.
@@ -898,9 +906,9 @@ PopupBox::draw_stat_4_box() {
 void
 PopupBox::draw_building_count(int x_, int y_, int type) {
   Player *player = interface->get_player();
-  draw_green_number(x_, y_,
+  int charactersDrawn = draw_green_number(x_, y_,
              player->get_completed_building_count((Building::Type)type));
-  draw_additional_number(x_+1, y_,
+  draw_additional_number(x_ + charactersDrawn, y_,
              player->get_incomplete_building_count((Building::Type)type));
 }
 

--- a/src/popup.h
+++ b/src/popup.h
@@ -223,7 +223,7 @@ class PopupBox : public GuiObject {
   void draw_large_box_background(BackgroundPattern sprite);
   void draw_box_row(int sprite, int y);
   void draw_green_string(int x, int y, const std::string &str);
-  void draw_green_number(int x, int y, int n);
+  int draw_green_number(int x, int y, int n);
   void draw_green_large_number(int x, int y, int n);
   void draw_additional_number(int x, int y, int n);
   unsigned int get_player_face_sprite(size_t face);


### PR DESCRIPTION
NOTE: The number of Building::TypeGoldSmelter was not saved in the saved game, and is therefore lost. It will be correct / saved in new games.

The number of buildings was not shown correct, if the the number was higher that 9 and one or more building where incomplete.

The number of buildings was not loaded correctly from save games from the old DOS version game. The building type was off by one.

Fixes #176.
