### PR TITLE
New feature: The '½' key opens next message

### DIFF
--- a/src/interface.cc
+++ b/src/interface.cc
@@ -1499,6 +1499,15 @@ Interface::handle_key_pressed(char key, int modifier) {
       break;
     }
 
+    case -67: { // '½'
+    	if (player->has_notification()) {
+    		open_message();
+    	} else {
+    		return_from_message();
+    	}
+		break;
+    }
+
     // new Forkserf debug overlay, highlight items on map and provide misc debug info as needed
     case 'd': {
       Log::Info["interface"] << "'d' key pressed, toggling LayerDebug";


### PR DESCRIPTION
The '½' key opens next message. If no new messages, you will be send back where you came from.