### PR TITLE
New Feature: Running sort

### DIFF
--- a/src/building.cc
+++ b/src/building.cc
@@ -66,6 +66,8 @@ Building::Building(Game *game, unsigned int index)
 
   holder_or_first_knight = 0;
   burning_counter = 0;
+
+  running_sort_active = false;
 }
 
 typedef struct ConstructionInfo {
@@ -1964,6 +1966,8 @@ Building::update_military() {
     }
   }
 
+  update_running_sort();
+
   /* Request gold */
   if (holder) {
     int total_gold = stock[1].requested + stock[1].available;
@@ -1975,6 +1979,143 @@ Building::update_military() {
       stock[1].prio = 0;
     }
   }
+}
+
+void
+Building::update_running_sort() {
+  Player *player = game->get_player(get_owner());
+
+  if (running_sort_active && stock[0].requested == 0) {
+    running_sort_active = false;
+    player->set_number_of_running_sort_in_progress(player->get_number_of_running_sort_in_progress() - 1);
+  }
+
+  if (player->get_running_sort_speed() == 0) {
+    // Running sort is off
+    return ;
+  }
+
+  if (!player->is_running_sort_active_for_game_tick()) {
+    return ;
+  }
+
+  unsigned int limit_of_running_sort_in_progress = player->get_running_sort_speed() * 20 / 65500 /* Max slider value (not 65535)*/;
+  if (limit_of_running_sort_in_progress == 0 && player->get_running_sort_speed() > 0) {
+    limit_of_running_sort_in_progress = 1;
+  }
+
+  if (player->get_number_of_running_sort_in_progress() >= limit_of_running_sort_in_progress) {
+    return ;
+  }
+
+  if (stock[0].requested != 0) {
+    // One knight(s) is on it ways already => Don't sort
+    return ;
+  }
+
+  int knight_score = 0;
+  Serf* worst_knight = find_worst_knight_in_defending_queue(knight_score);
+  if (worst_knight == NULL) {
+    // Building is not defended yet / is empty
+    return ;
+  }
+
+  if (worst_knight->get_type() == Serf::TypeKnight4) {
+    // Already the best knight => Don't sort
+    return ;
+  }
+
+  Building* best_knight_building;
+  Serf::Type best_knight_type = game->find_best_knight_type_available(this, best_knight_building, worst_knight->get_type());
+  if (best_knight_type == Serf::TypeNone || best_knight_type <= worst_knight->get_type()) {
+    // No better knight available => Don't sort
+    return ;
+  }
+
+  // The swap of knights is not done now. It is saved for later execution.
+  // It is only saved if it is better that the current swap, to only do the best swap e.g. swap the worst knight in worst defended building.
+  // The execution of the swap is done in the execute_best_running_sort, that is executed when all the building.update()'s have been executed.
+  player->set_running_sort_data(this, best_knight_building, best_knight_type, knight_score);
+}
+
+void
+Building::execute_best_running_sort(Building* best_knight_building, Serf::Type best_knight_type) {
+  // "Over request" a knight of best_knight_type from the best_knight_building to avoid defenses being down while sorting knights.
+  Player *player = game->get_player(get_owner());
+  if (!best_knight_building->has_inventory()) {
+    throw ExceptionFreeserf("!!best_knight_building->has_inventory()");
+  }
+
+  Inventory* best_knight_inventory = best_knight_building->get_inventory();
+  if (!best_knight_inventory->have_serf(best_knight_type)) {
+    // Knight has disappeared. Properly because the knight was missing in a building, which is later in the list of buildings.
+    // The swap is not executed.
+    return ;
+  }
+
+  // Copied from Game::send_serf_to_flag_search_cb(Flag *flag, void *d) and modified
+  Serf* best_knight = best_knight_inventory->call_out_serf(best_knight_type);
+  if (best_knight == NULL) {
+    throw ExceptionFreeserf("best_knight == NULL");
+  }
+
+  knight_request_granted();
+  best_knight->go_out_from_inventory(best_knight_inventory->get_index(), get_flag_index(), -1);
+  player->set_number_of_running_sort_in_progress(player->get_number_of_running_sort_in_progress() + 1);
+  running_sort_active = true;
+}
+
+Serf*
+Building::find_worst_knight_in_defending_queue(int &knight_score) {
+  // Copied from Building::update_castle() and modified
+  Serf *worst_knight = NULL;
+  knight_score = 0;
+  unsigned int next_serf_index = holder_or_first_knight;
+  while (next_serf_index != 0) {
+    Serf *serf = game->get_serf(next_serf_index);
+    if (serf == nullptr) {
+      throw ExceptionFreeserf("Index of nonexistent serf in the queue.");
+    }
+    knight_score += (serf->get_type() - Serf::TypeKnight0) * (serf->get_type() - Serf::TypeKnight0);
+    if (worst_knight == NULL || serf->get_type() < worst_knight->get_type()) {
+      worst_knight = serf;
+    }
+    next_serf_index = serf->get_next();
+  }
+
+  if (worst_knight != NULL) {
+  // Is intentionally reserved to make a bad knight reduce the score a lot
+    knight_score -= (Serf::TypeKnight4 - worst_knight->get_type() + 2) * (Serf::TypeKnight4 - worst_knight->get_type() + 2);
+  }
+
+  return worst_knight;
+}
+
+Serf::Type
+Building::find_best_knight_type_available() {
+  if (constructing) {
+    return Serf::TypeNone;
+  }
+
+  if (get_type() != TypeStock && get_type() != TypeCastle) {
+    return Serf::TypeNone;
+  }
+
+  if (!has_inventory()) {
+    return Serf::TypeNone;
+  }
+
+  if (!is_active()) {
+    return Serf::TypeNone;
+  }
+
+  for (int knight_type = Serf::TypeKnight4; knight_type >= Serf::TypeKnight0; knight_type--) {
+    if (inventory->have_serf((Serf::Type)knight_type)) {
+      return (Serf::Type)knight_type;
+    }
+  }
+
+  return Serf::TypeNone;
 }
 
 int
@@ -2203,6 +2344,10 @@ operator >> (SaveReaderText &reader, Building &building) {
     reader.value("level") >> building.u.level;
   }
 
+  if (reader.has_value("running_sort_active")) {
+	  building.running_sort_active = true;
+  }
+
   return reader;
 }
 
@@ -2245,6 +2390,10 @@ operator << (SaveWriterText &writer, Building &building) {
     writer.value("tick") << building.u.tick;
   } else {
     writer.value("level") << building.u.level;
+  }
+
+  if (building.running_sort_active) {
+	writer.value("running_sort_active") << 1; // 1 = true
   }
 
   return writer;

--- a/src/building.h
+++ b/src/building.h
@@ -294,6 +294,9 @@ class Building : public GameObject {
 
   void update(unsigned int tick);
 
+  Serf::Type find_best_knight_type_available();
+  void execute_best_running_sort(Building* best_knight_building, Serf::Type best_knight_type);
+
   friend SaveReaderBinary&
     operator >> (SaveReaderBinary &reader, Building &building);
   friend SaveReaderText&
@@ -307,6 +310,9 @@ class Building : public GameObject {
   void update_unfinished_adv();
   void update_castle();
   void update_military();
+  void update_running_sort();
+  Serf *find_worst_knight_in_defending_queue(int &knight_score);
+  bool running_sort_active;
 
   void request_serf_if_needed();
 

--- a/src/game.cc
+++ b/src/game.cc
@@ -933,6 +933,12 @@ Game::send_geologist(Flag *dest) {
 void
 Game::update_buildings() {
   mutex_lock("Game::update_buildings");
+
+  // Reset running sort data before Building::update()
+  for (Player *player : players) {
+    player->reset_running_sort_data();
+  }
+
   Buildings blds(buildings);
   Buildings::Iterator i = blds.begin();
   while (i != blds.end()) {
@@ -940,7 +946,60 @@ Game::update_buildings() {
     ++i;
     building->update(tick);
   }
+
+  // Execute best running sort data after Building::update()
+  for (Player *player : players) {
+    Building* worst_knight_building;
+    Building* best_knight_building;
+    Serf::Type best_knight_type;
+    player->get_running_sort_data(worst_knight_building, best_knight_building, best_knight_type);
+
+    if (worst_knight_building != NULL) {
+      worst_knight_building->execute_best_running_sort(best_knight_building, best_knight_type);
+    }
+
+    if (player->is_running_sort_active_for_game_tick()) {
+      player->set_last_game_tick_of_running_sort(get_tick());
+    }
+  }
+
   mutex_unlock();
+}
+
+Serf::Type
+Game::find_best_knight_type_available(Building *source_building, Building *&best_knight_building, Serf::Type minKnightType) {
+  Flag *source_flag = get_flag(source_building->get_flag_index());
+  Buildings blds(buildings);
+  Buildings::Iterator i = blds.begin();
+  Serf::Type best_knight_type = Serf::TypeNone;
+  while (i != blds.end()) {
+    Building *destination_building = *i;
+    ++i;
+    Serf::Type building_best_knight_type = destination_building->find_best_knight_type_available();
+    if ((best_knight_type == Serf::TypeNone || best_knight_type < building_best_knight_type) && minKnightType < building_best_knight_type) {
+      bool pathFound = FlagSearch::single(source_flag, find_best_knight_available_cb, true, false, destination_building);
+      if (pathFound) {
+        best_knight_type = building_best_knight_type;
+        best_knight_building = destination_building;
+      }
+    }
+  }
+
+  return best_knight_type;
+}
+
+bool
+Game::find_best_knight_available_cb(Flag *flag, void *data) {
+  if (!flag->has_building()) {
+    return false;
+  }
+
+  Building* destination = reinterpret_cast<Building*>(data);
+  if (flag->get_building() != destination) {
+    return false;
+  }
+
+  return true;
 }
 
 /* Update serfs as part of the game progression. */

--- a/src/game.h
+++ b/src/game.h
@@ -191,6 +191,11 @@ class Game {
   void speed_decrease();
   void speed_reset();
 
+  Serf::Type find_best_knight_type_available(Building *source_building, Building *&best_knight_building, Serf::Type minKnightType);
+ private:
+  static bool find_best_knight_available_cb(Flag *flag, void *data);
+ public:
+
   // hack function to allow Serf, Building to trigger game to flush the frame
   //  so for option_FogOfWar so FoW cna be updated only when borders change
   void set_must_redraw_frame() { must_redraw_frame = true; }

--- a/src/player.cc
+++ b/src/player.cc
@@ -161,6 +161,10 @@ Player::Player(Game* game, unsigned int index)
     serf_count[i] = 0;
   }
 
+  number_of_running_sort_in_progress = 0;
+  last_game_tick_of_running_sort = 0;
+  running_sort_speed = 0;
+
   /* TODO AI: Set array field_402 of length 25 to -1. */
   /* TODO AI: Set array field_434 of length 280*2 to 0 */
   /* TODO AI: Set array field_1bc of length 8 to -1 */
@@ -675,6 +679,35 @@ void
 Player::cycle_knights() {
   flags |= BIT(2) | BIT(4);
   knight_cycle_counter = 2400;
+}
+
+bool Player::is_running_sort_active_for_game_tick() {
+  unsigned int diff = game->get_tick() - get_last_game_tick_of_running_sort();
+  return diff > 1000;
+}
+
+void Player::reset_running_sort_data() {
+  running_sort_worst_knight_building = NULL;
+  running_sort_best_knight_building = NULL;
+  running_sort_best_knight_type = Serf::TypeNone;
+  running_sort_knight_score = -1;
+}
+
+void Player::get_running_sort_data(Building* &worst_knight_building, Building* &best_knight_building, Serf::Type &best_knight_type) {
+  worst_knight_building = running_sort_worst_knight_building;
+  best_knight_building = running_sort_best_knight_building;
+  best_knight_type = running_sort_best_knight_type;
+}
+
+void Player::set_running_sort_data(Building* worst_knight_building, Building* best_knight_building, Serf::Type best_knight_type, int knight_score) {
+  if (knight_score > running_sort_knight_score && running_sort_knight_score != - 1) {
+    return ;
+  }
+
+  running_sort_worst_knight_building = worst_knight_building;
+  running_sort_best_knight_building = best_knight_building;
+  running_sort_best_knight_type = best_knight_type;
+  running_sort_knight_score = knight_score;
 }
 
 void
@@ -1445,6 +1478,16 @@ operator >> (SaveReaderText &reader, Player &player) {
   reader.value("castle_knights") >> player.castle_knights;
   reader.value("castle_knights_wanted") >> player.castle_knights_wanted;
 
+  if (reader.has_value("number_of_running_sort_in_progress")) {
+    reader.value("number_of_running_sort_in_progress") >> player.number_of_running_sort_in_progress;
+  }
+  if (reader.has_value("last_game_tick_of_running_sort")) {
+    reader.value("last_game_tick_of_running_sort") >> player.last_game_tick_of_running_sort;
+  }
+  if (reader.has_value("running_sort_speed")) {
+    reader.value("running_sort_speed") >> player.running_sort_speed;
+  }
+
   return reader;
 }
 
@@ -1526,6 +1569,10 @@ operator << (SaveWriterText &writer, Player &player) {
 
   writer.value("castle_knights") << player.castle_knights;
   writer.value("castle_knights_wanted") << player.castle_knights_wanted;
+
+  writer.value("number_of_running_sort_in_progress") << player.number_of_running_sort_in_progress;
+  writer.value("last_game_tick_of_running_sort") << player.last_game_tick_of_running_sort;
+  writer.value("running_sort_speed") << player.running_sort_speed;
 
   return writer;
 }

--- a/src/player.h
+++ b/src/player.h
@@ -163,6 +163,13 @@ class Player : public GameObject {
   int player_stat_history[16][112];
   int resource_count_history[26][120];
 
+  unsigned int number_of_running_sort_in_progress;
+  unsigned int last_game_tick_of_running_sort;
+  unsigned int running_sort_speed;
+  Building* running_sort_worst_knight_building;
+  Building* running_sort_best_knight_building;
+  Serf::Type running_sort_best_knight_type;
+  int running_sort_knight_score;
  public:
   // TODO(Digger): remove it to UI
   int building_attacked;
@@ -336,6 +343,18 @@ class Player : public GameObject {
   void set_wheat_pigfarm(int val) { wheat_pigfarm = val; }
   int get_wheat_mill() const { return wheat_mill; }
   void set_wheat_mill(int val) { wheat_mill = val; }
+
+  unsigned int get_number_of_running_sort_in_progress() const { return number_of_running_sort_in_progress; }
+  void set_number_of_running_sort_in_progress(unsigned int val) { number_of_running_sort_in_progress = val; }
+  unsigned int get_last_game_tick_of_running_sort() const { return last_game_tick_of_running_sort; }
+  bool is_running_sort_active_for_game_tick();
+  void set_last_game_tick_of_running_sort(unsigned int val) { last_game_tick_of_running_sort = val; }
+  unsigned int get_running_sort_speed() const { return running_sort_speed; }
+  void set_running_sort_speed(unsigned int val) { running_sort_speed = val; }
+
+  void get_running_sort_data(Building* &worst_knight_building, Building* &best_knight_building, Serf::Type &best_knight_type);
+  void set_running_sort_data(Building* worst_knight_building, Building* best_knight_building, Serf::Type best_knight_type, int knight_score);
+  void reset_running_sort_data();
 
   friend SaveReaderBinary&
     operator >> (SaveReaderBinary &reader, Player &player);

--- a/src/popup.cc
+++ b/src/popup.cc
@@ -244,6 +244,7 @@ typedef enum Action {
   ACTION_SHOW_SETT_8,
   ACTION_SHOW_SETT_6,
   ACTION_SETT_8_ADJUST_RATE,
+  ACTION_SETT_8_ADJUST_RUNNING_SORT,
   ACTION_SETT_8_TRAIN_1,
   ACTION_SETT_8_TRAIN_5,
   ACTION_SETT_8_TRAIN_20,
@@ -3029,6 +3030,9 @@ PopupBox::draw_sett_8_box() {
 
   draw_green_large_number(6, 73, player->get_gold_deposited());
 
+  // Running sort gui
+  draw_slide_bar(8, 80, player->get_running_sort_speed());
+
   draw_green_number(6, 119, player->get_castle_knights_wanted());
   draw_green_number(6, 129, player->get_castle_knights());
 
@@ -4574,6 +4578,9 @@ PopupBox::handle_action(int action, int x_, int /*y_*/) {
   case ACTION_SETT_8_ADJUST_RATE:
     player->set_serf_to_knight_rate(gui_get_slider_click_value(x_));
     break;
+  case ACTION_SETT_8_ADJUST_RUNNING_SORT:
+	player->set_running_sort_speed(gui_get_slider_click_value(x_));
+    break;
   case ACTION_SETT_8_TRAIN_1:
     sett_8_train(1);
     break;
@@ -5413,6 +5420,8 @@ PopupBox::handle_sett_8_click(int cx, int cy) {
 
     ACTION_SETT_8_SET_COMBAT_MODE_WEAK, 48, 84, 16, 16,
     ACTION_SETT_8_SET_COMBAT_MODE_STRONG, 48, 100, 16, 16,
+
+	ACTION_SETT_8_ADJUST_RUNNING_SORT, 64, 80, 64, 8,
 
     ACTION_SETT_8_CYCLE, 80, 84, 32, 32,
 


### PR DESCRIPTION
This implements the new feature: Running Sort (Continuous / slow knight sorting)

If a knight in the castle (or stock) is better trained that a knight in a outpost (Hut, tower or fortress) they are swapped.
The user can set a limit (0 - 20) on how many knights currently are being swapped. If the limit is set to 0 "Running sort" is off.

This is not like the original version (ACTION_SETT_8_CYCLE), where a knight is swapped from EVERY outpost with more than one knight, causing a traffic jam at the castle.

"Running Sort" will find the worst knight in the worst defended outpost (Hut, tower or fortress), and replace it with the best knight available in the castle or stock (If reachable). The knight will be swap at the outpost, to avoid that the defenses is down during the swap. Only one knight is swap per outpost, but multiple outpost can have knights swapping in progress at the same time.

Setting the limit to 1 (Very low) from the start and keep it there seem to be good enough to always have your knights sorted.